### PR TITLE
Set overlay opacity opposite to view opacity

### DIFF
--- a/dist/DrawerLayout.js
+++ b/dist/DrawerLayout.js
@@ -363,16 +363,16 @@ var DrawerLayout = (_temp = _class = (function(_Component) {
         };
         var drawerOutputRange = void 0;
         var mainOutputRange = void 0;
-        var viewMovement = 0;
+        var viewDisplacement = 0;
         if (moveView) {
-          viewMovement = drawerWidth + spaceOnOpen;
+          viewDisplacement = drawerWidth + spaceOnOpen;
         }
         if (this.getDrawerPosition() === 'left') {
           drawerOutputRange = [-drawerWidth, 0];
-          mainOutputRange = [0, viewMovement];
+          mainOutputRange = [0, viewDisplacement];
         } else {
           drawerOutputRange = [drawerWidth, 0];
-          mainOutputRange = [0, -viewMovement];
+          mainOutputRange = [0, -viewDisplacement];
         }
         var drawerTranslateX = openValue.interpolate({
           inputRange: [0, 1],
@@ -392,7 +392,7 @@ var DrawerLayout = (_temp = _class = (function(_Component) {
         };
         var overlayOpacity = openValue.interpolate({
           inputRange: [0, 1],
-          outputRange: [0, viewOpacity],
+          outputRange: [0, 1 - viewOpacity],
           extrapolate: 'clamp',
         });
         var animatedOverlayStyles = { opacity: overlayOpacity };
@@ -457,7 +457,7 @@ var DrawerLayout = (_temp = _class = (function(_Component) {
   useNativeAnimations: false,
   moveView: false,
   spaceOnOpen: 0,
-  viewOpacity: 0.7,
+  viewOpacity: 0,
 }, _class.positions = { Left: 'left', Right: 'right' }, _temp);
 exports.default = DrawerLayout;
 

--- a/src/DrawerLayout.js
+++ b/src/DrawerLayout.js
@@ -36,7 +36,7 @@ export type PropType = {
   useNativeAnimations?: boolean,
   moveView?: boolean,
   spaceOnOpen?: number,
-  viewOpacity?: number,
+  viewOpacity: number,
 };
 
 export type StateType = {
@@ -76,7 +76,7 @@ export default class DrawerLayout extends Component {
     useNativeAnimations: false,
     moveView: false,
     spaceOnOpen: 0,
-    viewOpacity: 0.7,
+    viewOpacity: 0,
   };
 
   static positions = {
@@ -158,18 +158,18 @@ export default class DrawerLayout extends Component {
     /* Drawer styles */
     let drawerOutputRange;
     let mainOutputRange;
-    let viewMovement = 0;
+    let viewDisplacement = 0;
 
     if (moveView) {
-      viewMovement = drawerWidth + spaceOnOpen;
+      viewDisplacement = drawerWidth + spaceOnOpen;
     }
 
     if (this.getDrawerPosition() === 'left') {
       drawerOutputRange = [-drawerWidth, 0];
-      mainOutputRange = [0, viewMovement];
+      mainOutputRange = [0, viewDisplacement];
     } else {
       drawerOutputRange = [drawerWidth, 0];
-      mainOutputRange = [0, -viewMovement];
+      mainOutputRange = [0, -viewDisplacement];
     }
 
     const drawerTranslateX = openValue.interpolate({
@@ -193,7 +193,7 @@ export default class DrawerLayout extends Component {
     /* Overlay styles */
     const overlayOpacity = openValue.interpolate({
       inputRange: [0, 1],
-      outputRange: [0, viewOpacity],
+      outputRange: [0, 1 - viewOpacity],
       extrapolate: 'clamp',
     });
 


### PR DESCRIPTION
1. Set overlay opacity opposite to view opacity
1. Renamed 'viewMovement' to 'viewDisplacement'